### PR TITLE
Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,12 +1,9 @@
 preset: symfony
 
-linting: true
-
 enabled:
-    - ordered_use
-    - strict
-    - no_spaces_after_function_name
+  - ordered_imports
+  - strict_comparison
 
 disabled:
-    - empty_return
-
+  - function_declaration
+  - simplified_null_return


### PR DESCRIPTION
I've:
- updated the fixer names with the official names (ie, resolved the aliased names to the real ones)
- disabled the fixer that messes with `function(` as requested
- linting is enabled by default, and infact, can't be turned off anymore
